### PR TITLE
Import `pi` from the numpy package

### DIFF
--- a/src/wave/wave1D/wave1D_u0.py
+++ b/src/wave/wave1D/wave1D_u0.py
@@ -206,9 +206,9 @@ def guitar(C):
     freq = 440
     wavelength = 2*L
     c = freq*wavelength
-    omega = 2*pi*freq
+    omega = 2*np.pi*freq
     num_periods = 1
-    T = 2*pi/omega*num_periods
+    T = 2*np.pi/omega*num_periods
     # Choose dt the same as the stability limit for Nx=50
     dt = L/50./c
 


### PR DESCRIPTION
This fixes the following error:

    .../fdm-book/src/wave/wave1D/wave1D_u0.py in guitar(C)
        207     wavelength = 2*L
        208     c = freq*wavelength
    --> 209     omega = 2*pi*freq
        210     num_periods = 1
        211     T = 2*pi/omega*num_periods

    NameError: global name 'pi' is not defined